### PR TITLE
Performance: Don't overwrite existing ETag headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,14 @@ module.exports = function(options) {
 		reshook: function(server, tile, req, res, result, callback) {
 			var status_type = result.status / 100 | 0;
 			if (status_type === 2 && result.buffer && result.buffer.length < max_length) {
-				result.headers['ETag'] = etag(result.buffer);
+				var resultEtag = result.headers['etag'];
+				if (!resultEtag) {
+					resultEtag = etag(result.buffer);
+					result.headers['ETag'] = resultEtag;
+				}
+
 				var ifnonematch = req.headers['if-none-match'];
-				if (ifnonematch && ifnonematch === result.headers['ETag']) {
+				if (ifnonematch && ifnonematch === resultEtag) {
 					result.status = 304;
 					result.buffer = new Buffer([]);
 				}


### PR DESCRIPTION
Don't recompute the ETag if it already exists, e.g. if the upstream server already did set one, or if it was in the cache, or if it was already set by some tile provider.
